### PR TITLE
Added support for password hashes

### DIFF
--- a/ntlm_auth/compute_hash.py
+++ b/ntlm_auth/compute_hash.py
@@ -26,10 +26,15 @@ def _lmowfv1(password):
     Same function as LMOWFv1 in document to create a one way hash of the password. Only
     used in NTLMv1 auth without session security
 
-    :param password: The password of the user we are trying to authenticate with
+    :param password: The password or hash of the user we are trying to authenticate with
     :return res: A Lan Manager hash of the password supplied
     """
-
+    
+    # if the password is a hash, return the LM hash
+    if re.match(r'^[a-fA-F\d]{32}:[a-fA-F\d]{32}$', password):
+        lm_hash = binascii.unhexlify(password.split(':')[0])
+        return lm_hash
+    
     # fix the password length to 14 bytes
     password = password.upper()
     lm_pw = password[0:14]
@@ -54,10 +59,15 @@ def _ntowfv1(password):
     Same function as NTOWFv1 in document to create a one way hash of the password. Only
     used in NTLMv1 auth without session security
 
-    :param password: The password of the user we are trying to authenticate with
+    :param password: The password or hash of the user we are trying to authenticate with
     :return digest: An NT hash of the password supplied
     """
-
+    
+    # if the password is a hash, return the NT hash
+    if re.match(r'^[a-fA-F\d]{32}:[a-fA-F\d]{32}$', password):
+        nt_hash = binascii.unhexlify(password.split(':')[1])
+        return nt_hash
+    
     digest = hashlib.new('md4', password.encode('utf-16le')).digest()
     return digest
 

--- a/tests/expected_values.py
+++ b/tests/expected_values.py
@@ -16,6 +16,7 @@ from .utils import HexToByte
 user_name = 'User'
 domain_name = 'Domain'
 password = 'Password'
+password_hash = 'e52cac67419a9a224a3b108f3fa6cb6d:a4f49c406510bdcab6824ee7c30fd852'
 server_name = HexToByte('53 00 65 00 72 00 76 00 65 00 72 00')
 workstation_name = HexToByte('43 00 4f 00 4d 00 50 00 55 00 54 00 45 00 52 00').decode()
 

--- a/tests/unit/test_compute_hash.py
+++ b/tests/unit/test_compute_hash.py
@@ -40,6 +40,14 @@ class Test_ComputeHash(unittest.TestCase):
     def test_ntofv1_hash(self):
         expected = ntlmv1_ntowfv1
 
-        actual = comphash._ntofv2(user_name, password_hash, domain_name)
+        actual = comphash._ntowfv1(password)
+
+        assert actual == expected
+
+    # 4.2.4.1.1 - NTOWFv2() and LMOWFv2()
+    def test_ntowfv2(self):
+        expected = ntlmv2_ntowfv2
+
+        actual = comphash._ntowfv2(user_name, password, domain_name)
 
         assert actual == expected

--- a/tests/unit/test_compute_hash.py
+++ b/tests/unit/test_compute_hash.py
@@ -27,3 +27,19 @@ class Test_ComputeHash(unittest.TestCase):
         actual = comphash._ntowfv2(user_name, password, domain_name)
 
         assert actual == expected
+
+    # 4.2.2.1.1 - LMOWFv1()
+    def test_lmofv1_hash(self):
+        expected = ntlmv1_lmowfv1
+
+        actual = comphash._lmowfv1(password_hash)
+
+        assert actual == expected
+
+    # 4.2.2.1.2 - NTOWFv1()
+    def test_ntofv1_hash(self):
+        expected = ntlmv1_ntowfv1
+
+        actual = comphash._ntofv2(user_name, password_hash, domain_name)
+
+        assert actual == expected

--- a/tests/unit/test_compute_hash.py
+++ b/tests/unit/test_compute_hash.py
@@ -40,7 +40,7 @@ class Test_ComputeHash(unittest.TestCase):
     def test_ntofv1_hash(self):
         expected = ntlmv1_ntowfv1
 
-        actual = comphash._ntowfv1(password)
+        actual = comphash._ntowfv1(password_hash)
 
         assert actual == expected
 
@@ -48,6 +48,6 @@ class Test_ComputeHash(unittest.TestCase):
     def test_ntowfv2(self):
         expected = ntlmv2_ntowfv2
 
-        actual = comphash._ntowfv2(user_name, password, domain_name)
+        actual = comphash._ntowfv2(user_name, password_hash, domain_name)
 
         assert actual == expected


### PR DESCRIPTION
Allow the use hashes in the format of LM_HASH:NT_HASH in place of a password. 