### PR TITLE
Expose session key for libraries that require this value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 1.4.0 (Aug 19, 2019(
+
+* Added the `session_key` attribute to the `NtlmContext` class publically expose the session key negotiated in the auth.
+
 ## 1.3.0 (Apr 9, 2019)
 
 * Added optional dependency for `cryptography` for faster RC4 cipher calls

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 # Changes
 
-## 1.4.0 (Aug 19, 2019(
+## 1.4.0 (Aug 19, 2019)
 
-* Added the `session_key` attribute to the `NtlmContext` class publically expose the session key negotiated in the auth.
+* Added the `session_key` attribute to the `NtlmContext` class so the session key can be accessed in downstream libraries
 
 ## 1.3.0 (Apr 9, 2019)
 

--- a/ntlm_auth/ntlm.py
+++ b/ntlm_auth/ntlm.py
@@ -49,6 +49,7 @@ class NtlmContext(object):
         self._server_certificate_hash = None  # deprecated for backwards compat
         self.ntlm_compatibility = ntlm_compatibility
         self.complete = False
+        self.session_key = None
 
         # Setting up our flags so the challenge message returns the target info
         # block if supported
@@ -91,6 +92,7 @@ class NtlmContext(object):
             flags = struct.unpack("<I", flag_bytes)[0]
             if flags & NegotiateFlags.NTLMSSP_NEGOTIATE_SEAL or \
                     flags & NegotiateFlags.NTLMSSP_NEGOTIATE_SIGN:
+                self.session_key = self._authenticate_message.exported_session_key
                 self._session_security = SessionSecurity(
                     flags, self._authenticate_message.exported_session_key
                 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='ntlm-auth',
-    version='1.3.0',
+    version='1.4.0',
     packages=['ntlm_auth'],
     install_requires=[],
     extras_require={


### PR DESCRIPTION
I have a need to access the session key generated in the NTLM context in another Python library. This exposes the session key in a public way instead of relying on `_session_security` which could change in the future.