### PR TITLE
Fix bug when clearing NTLMSSP_NEGOTIATE_OEM flag

### DIFF
--- a/ntlm_auth/messages.py
+++ b/ntlm_auth/messages.py
@@ -331,7 +331,7 @@ class AuthenticateMessage(object):
             self.workstation = workstation
 
         if self.negotiate_flags & NegotiateFlags.NTLMSSP_NEGOTIATE_UNICODE:
-            self.negotiate_flags -= NegotiateFlags.NTLMSSP_NEGOTIATE_OEM
+            self.negotiate_flags &= ~NegotiateFlags.NTLMSSP_NEGOTIATE_OEM
             encoding_value = 'utf-16-le'
         else:
             encoding_value = 'ascii'


### PR DESCRIPTION
Make sure to not modify any other negotiate flags when clearing
NTLMSSP_NEGOTIATE_OEM in server response.

Previous code could cause various problems depending on which negotiate
flags that were set in the server response, e.g. wrongly clearing
NTLMSSP_NEGOTIATE_SIGN resulted in the session key not being set.